### PR TITLE
Make PhantomType.Tag public

### DIFF
--- a/core/src/main/scala/busymachines/pureharm/core/PhantomType.scala
+++ b/core/src/main/scala/busymachines/pureharm/core/PhantomType.scala
@@ -35,7 +35,7 @@ import tag.@@
   *
   */
 trait PhantomType[T] {
-  protected type Tag <: this.type
+  type Tag <: this.type
   final type Type = T @@ Tag
 
   @inline final def apply(value: T): T @@ Tag =


### PR DESCRIPTION
It's needed to sometimes write generic typeclasses for any PhantomType