### PR TITLE
[effects] Add FutureLift typeclass for safely lifting a Future into F[_]

### DIFF
--- a/effects-cats/src/main/scala/busymachines/pureharm/effects_impl/FutureLift.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/effects_impl/FutureLift.scala
@@ -1,0 +1,54 @@
+/**
+  * Copyright (c) 2019 BusyMachines
+  *
+  * See company homepage at: https://www.busymachines.com/
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package busymachines.pureharm.effects_impl
+
+import scala.annotation.{implicitAmbiguous, implicitNotFound}
+import scala.concurrent.Future
+
+/**
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 13 Jun 2019
+  *
+  */
+@implicitAmbiguous(
+  "FutureLift needs a bunch of machinery. Make sure you don't have two implicit scala.concurrent.ExecutionContext, or two cats.effect.ContextShift[F] in scope, or two LiftIO[F]",
+)
+@implicitNotFound(
+  "FutureLift can only be instantiated for ContextShift[IO] for F[_]: LiftIO. You should instantiate one of these in your main, and propagate it further",
+)
+trait FutureLift[F[_]] {
+  def fromFuture[A](fut: => Future[A]): F[A]
+}
+
+object FutureLift {
+
+  def apply[F[_]](implicit fl: FutureLift[F]): FutureLift[F] = fl
+
+  import cats.effect._
+
+  implicit def instance[F[_]: LiftIO](implicit cs: ContextShift[IO]): FutureLift[F] = new FutureLiftIO[F]
+
+  final private[FutureLift] class FutureLiftIO[F[_]](
+    implicit
+    private val cs:     ContextShift[IO],
+    private val liftIO: LiftIO[F],
+  ) extends FutureLift[F] {
+    override def fromFuture[A](fut: => Future[A]): F[A] = IO.fromFuture(IO(fut)).to[F]
+  }
+}

--- a/effects-cats/src/main/scala/busymachines/pureharm/effects_impl/definitions/PureharmEffectsTypeDefinitions.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/effects_impl/definitions/PureharmEffectsTypeDefinitions.scala
@@ -251,6 +251,9 @@ trait PureharmEffectsTypeDefinitions {
   final type BracketAttempt[F[_]] = effects_impl.types.BracketAttempt[F]
   final val BracketAttempt: effects_impl.BracketAttempt.type = effects_impl.BracketAttempt
 
+  final type FutureLift[F[_]] = effects_impl.FutureLift[F]
+  final val FutureLift: effects_impl.FutureLift.type = effects_impl.FutureLift
+
   //----------- standard scala types -----------
 
   //brought in for easy pattern matching. Failure, and Success are used way too often

--- a/effects-cats/src/test/scala/busymachines/pureharm/effects_impl/PureharmSyntaxTest.scala
+++ b/effects-cats/src/test/scala/busymachines/pureharm/effects_impl/PureharmSyntaxTest.scala
@@ -370,7 +370,7 @@ final class PureharmSyntaxTest extends AnyFunSpec {
       }
     }
 
-    describe("suspendIn[...]") {
+    describe("purifyIn[...]") {
       implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
       test("... IO") {
@@ -378,7 +378,7 @@ final class PureharmSyntaxTest extends AnyFunSpec {
         val io: IO[Int] = Future[Int] {
           sideEffect = 42
           sideEffect
-        }.suspendIn[IO]
+        }.purifyIn[IO]
         // we wait because in case this doesn't work,
         // the Future is already running and doing all its side-effects
         Thread.sleep(100)
@@ -394,7 +394,7 @@ final class PureharmSyntaxTest extends AnyFunSpec {
           val f: F[Int] = Future[Int] {
             sideEffect = 42
             sideEffect
-          }.suspendIn[F]
+          }.purifyIn[F]
           // we wait because in case this doesn't work,
           // the Future is already running and doing all its side-effects
           Thread.sleep(100)


### PR DESCRIPTION
This fixes the problem of IO.fromFuture requiring a ContextShift[IO] in scope, thus making it hard to lift futures into a polymorphic effect type