### PR TITLE
[db] Remove DBPort because it doesn't make sense in most cases

### DIFF
--- a/db/submodules/core/src/main/scala/busymachines/pureharm/db/DBConnectionConfig.scala
+++ b/db/submodules/core/src/main/scala/busymachines/pureharm/db/DBConnectionConfig.scala
@@ -8,12 +8,12 @@ package busymachines.pureharm.db
   */
 final case class DBConnectionConfig(
   host:     DBHost,
-  port:     DBPort,
   dbName:   DatabaseName,
   username: DBUsername,
   password: DBPassword,
 ) {
-  def jdbcURL: JDBCUrl = JDBCUrl.postgresql(host, port, dbName)
+
+  def jdbcURL: JDBCUrl = JDBCUrl.postgresql(host, dbName)
 }
 
 import busymachines.pureharm.config._

--- a/db/submodules/core/src/main/scala/busymachines/pureharm/db/PureharmDBCoreTypeDefinitions.scala
+++ b/db/submodules/core/src/main/scala/busymachines/pureharm/db/PureharmDBCoreTypeDefinitions.scala
@@ -42,9 +42,6 @@ trait PureharmDBCoreTypeDefinitions {
   final val DBHost: db.DBHost.type = db.DBHost
   final type DBHost = db.DBHost
 
-  final val DBPort: db.DBPort.type = db.DBPort
-  final type DBPort = db.DBPort
-
   final val JDBCUrl: db.JDBCUrl.type = db.JDBCUrl
   final type JDBCUrl = db.JDBCUrl.Type
 

--- a/db/submodules/core/src/main/scala/busymachines/pureharm/db/package.scala
+++ b/db/submodules/core/src/main/scala/busymachines/pureharm/db/package.scala
@@ -26,16 +26,18 @@ import busymachines.pureharm.phantom.PhantomType
   *
   */
 package object db {
-  final object DBPort extends PhantomType[Int]
-  final type DBPort = DBPort.Type
-
   final object DBHost extends PhantomType[String]
+
+  /**
+    * Please include port in host, if needed, e.g.
+    * {{{localhost:5432}}}
+    */
   final type DBHost = DBHost.Type
 
   final object JDBCUrl extends PhantomType[String] {
 
-    def postgresql(host: DBHost, port: DBPort, db: DatabaseName): this.Type =
-      this.apply(s"jdbc:postgresql://$host:$port/$db")
+    def postgresql(host: DBHost, db: DatabaseName): this.Type =
+      this.apply(s"jdbc:postgresql://$host/$db")
   }
 
   final type JDBCUrl = JDBCUrl.Type

--- a/db/submodules/core/src/test/resources/reference.conf
+++ b/db/submodules/core/src/test/resources/reference.conf
@@ -1,8 +1,7 @@
 pureharm {
   db {
     connection {
-      host: "localhost"
-      port: 20010
+      host: "localhost:20010"
       db-name: "pureharm_test"
       username: "pureharmony"
       password: "pureharmony"

--- a/db/submodules/core/src/test/scala/busymachines/pureharm/db/test/DBConnectionConfigTest.scala
+++ b/db/submodules/core/src/test/scala/busymachines/pureharm/db/test/DBConnectionConfigTest.scala
@@ -18,8 +18,7 @@ final class DBConnectionConfigTest extends PureharmFixtureTest {
     DBConnectionConfig.default[IO].map { config =>
       assert(
         config == DBConnectionConfig(
-          host     = DBHost("localhost"),
-          port     = DBPort(20010),
+          host     = DBHost("localhost:20010"),
           dbName   = DatabaseName("pureharm_test"),
           username = DBUsername("pureharmony"),
           password = DBPassword("pureharmony"),

--- a/db/submodules/slick-psql/src/test/scala/busymachines/pureharm/dbslick/psql/test/DAOAlgebraPureharmRowsTest.scala
+++ b/db/submodules/slick-psql/src/test/scala/busymachines/pureharm/dbslick/psql/test/DAOAlgebraPureharmRowsTest.scala
@@ -119,8 +119,7 @@ private[test] object DAOAlgebraPureharmRowsTest {
     *
     */
   private val dbConfig = DBConnectionConfig(
-    host     = DBHost("localhost"),
-    port     = DBPort(20010),
+    host     = DBHost("localhost:20010"),
     dbName   = DatabaseName("pureharm_test"),
     username = DBUsername("pureharmony"),
     password = DBPassword("pureharmony"),


### PR DESCRIPTION
Removes the type `DBPort` altogether. _If_ needed, it should just be included in the host `localhost:5432`, like standard.

In cases where the DB is at a named host behind a DNS resolved name (e.g. when using AWS RDS)  the API was basically unusable since you don't need to express the port, and it led to awkward configs.

Brutal and surprising removal, but still, it didn't go through a deprecation period, because in certain cases it doesn't make sense, and is a fairly small change.