### PR TITLE
db syntax

### DIFF
--- a/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/Flyway.scala
+++ b/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/Flyway.scala
@@ -32,6 +32,20 @@ object Flyway {
   import busymachines.pureharm.effects.implicits._
 
   def migrate[F[_]](
+    url:          JDBCUrl,
+    username:     DBUsername,
+    password:     DBPassword,
+    flywayConfig: Option[FlywayConfig],
+  )(
+    implicit F: Sync[F],
+  ): F[Int] = {
+    for {
+      fw   <- flywayInit[F](url, username, password, flywayConfig)
+      migs <- F.delay(fw.migrate())
+    } yield migs
+  }
+
+  def migrate[F[_]](
     dbConfig:     DBConnectionConfig,
     flywayConfig: Option[FlywayConfig] = Option.empty,
   )(

--- a/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/package.scala
+++ b/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/package.scala
@@ -10,7 +10,12 @@ import busymachines.pureharm.phantom._
   */
 package object flyway {
 
-  object MigrationLocation extends PhantomType[String]
+  object MigrationLocation extends PhantomType[String] {
+    /**
+      * The default location of flyway migrations
+      */
+    def default: this.Type = this.apply("db/migration")
+  }
   type MigrationLocation = MigrationLocation.Type
 
   object SchemaName extends PhantomType[String]

--- a/db/submodules/slick/src/main/scala/busymachines/pureharm/dbslick/PureharmSlickDBProfile.scala
+++ b/db/submodules/slick/src/main/scala/busymachines/pureharm/dbslick/PureharmSlickDBProfile.scala
@@ -96,7 +96,7 @@ trait PureharmSlickDBProfile extends PureharmDBCoreTypeDefinitions with Pureharm
     */
   trait PureharmSlickAPIWithImplicits
       extends self.API with PureharmSlickInstances.PhantomTypeInstances with SlickConnectionIOCatsInstances
-      with SlickQueryAlgebraDefinitions with SlickAliases {
+      with PureharmSlickConnectionIOOps.Implicits with SlickQueryAlgebraDefinitions with SlickAliases {
     final override protected val enclosingProfile: slick.jdbc.JdbcProfile = self
   }
 

--- a/db/submodules/slick/src/main/scala/busymachines/pureharm/dbslick/instances.scala
+++ b/db/submodules/slick/src/main/scala/busymachines/pureharm/dbslick/instances.scala
@@ -17,7 +17,7 @@
   */
 package busymachines.pureharm.dbslick
 
-import busymachines.pureharm.internals.dbslick.SlickConnectionIOCatsInstances
+import busymachines.pureharm.internals.dbslick.{PureharmSlickConnectionIOOps, SlickConnectionIOCatsInstances}
 
 /**
   *
@@ -25,4 +25,4 @@ import busymachines.pureharm.internals.dbslick.SlickConnectionIOCatsInstances
   * @since 13 Jun 2019
   *
   */
-object instances extends SlickConnectionIOCatsInstances
+object instances extends SlickConnectionIOCatsInstances with PureharmSlickConnectionIOOps.Implicits

--- a/db/submodules/slick/src/main/scala/busymachines/pureharm/internals/dbslick/PureharmSlickConnectionIOOps.scala
+++ b/db/submodules/slick/src/main/scala/busymachines/pureharm/internals/dbslick/PureharmSlickConnectionIOOps.scala
@@ -1,0 +1,31 @@
+package busymachines.pureharm.internals.dbslick
+
+import busymachines.pureharm.dbslick.ConnectionIO
+import slick.dbio.{DBIOAction, Effect, NoStream}
+
+/**
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 01 Aug 2019
+  *
+  */
+object PureharmSlickConnectionIOOps {
+
+  trait Implicits {
+    implicit def pureharmSlickWidenCIO[R, S <: NoStream, Eff <: Effect](
+      cio: DBIOAction[R, S, Eff],
+    ): PureharmSlickWidenCIO[R, S, Eff] = new PureharmSlickWidenCIO(cio)
+  }
+
+  final class PureharmSlickWidenCIO[R, S <: NoStream, Eff <: Effect](val cio: DBIOAction[R, S, Eff]) extends AnyVal {
+
+    /**
+      * Necessary because type inference kinda fails when you have something like:
+      * DBIOAction[R, NoStream, Effect.Read] and you want a ConnectionIO[R] to use all
+      * fancy ops. You can easily assign such a type to something of type ConnectionIO[R],
+      * but syntax OPS are not being added.
+      */
+    def widenCIO: ConnectionIO[R] = cio.asInstanceOf[ConnectionIO[R]] //it's always safe to widen
+  }
+
+}

--- a/db/submodules/slick/src/main/scala/busymachines/pureharm/internals/dbslick/SlickQueryAlgebraDefinitions.scala
+++ b/db/submodules/slick/src/main/scala/busymachines/pureharm/internals/dbslick/SlickQueryAlgebraDefinitions.scala
@@ -96,18 +96,18 @@ trait SlickQueryAlgebraDefinitions {
         case NonFatal(e) => SlickDBEntryNotFoundAnomaly(pk.show, Option(e))
       }
 
-    def insert(e: E): ConnectionIO[PK] = (dao.+=(e): ConnectionIO[Int]).map(_ => eid(e))
+    def insert(e: E): ConnectionIO[PK] = dao.+=(e).widenCIO.map(_ => eid(e))
 
-    def insertMany(es: Iterable[E]): ConnectionIO[Unit] = (dao.++=(es): ConnectionIO[Option[Int]]).void
+    def insertMany(es: Iterable[E]): ConnectionIO[Unit] = dao.++=(es).widenCIO.void
 
     def update(e: E): ConnectionIO[E] = (dao.update(e): ConnectionIO[Int]).map(_ => e)
 
     def updateMany[M[_]: Traverse](es: M[E]): ConnectionIO[Unit] = es.traverse_((e: E) => update(e))
 
-    def delete(pk: PK): ConnectionIO[Unit] = (dao.filter(_.id === pk).delete: ConnectionIO[Int]).void
+    def delete(pk: PK): ConnectionIO[Unit] = dao.filter(_.id === pk).delete.widenCIO.void
 
     def deleteMany(pks: Iterable[PK]): ConnectionIO[Unit] =
-      (dao.filter(_.id.inSet(pks)).delete: ConnectionIO[Int]).void
+      dao.filter(_.id.inSet(pks)).delete.widenCIO.void
 
     def exists(pk: PK): ConnectionIO[Boolean] = dao.filter(_.id === pk).exists.result
 


### PR DESCRIPTION
1. Add syntax to widen slick's DBIO.  Useful for using cats syntax on slick queries, e.g:
```
def delete(pk: PK): ConnectionIO[Unit] = dao.filter(_.id === pk).delete.widenCIO.void
```
Without the `widenCIO` the Ops defined on `ConnectionIO[_]` are not resolved.

2. Add missing overload on new Flyway object
3. Add default method for `flyway.MigrationLocation`