### PR TITLE
Upgrade: versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,7 +347,7 @@ lazy val `db-slick-psql` = subModule("db", "slick-psql")
 
 lazy val scalaCollCompatVersion: String = "2.1.1"        //https://github.com/scala/scala-collection-compat/releases
 lazy val shapelessVersion:       String = "2.3.3"        //https://github.com/milessabin/shapeless/releases
-lazy val catsVersion:            String = "2.0.0-M4"     //https://github.com/typelevel/cats/releases
+lazy val catsVersion:            String = "2.0.0-RC1"    //https://github.com/typelevel/cats/releases
 lazy val catsEffectVersion:      String = "2.0.0-M5"     //https://github.com/typelevel/cats-effect/releases
 lazy val circeVersion:           String = "0.12.0-M4"    //https://github.com/circe/circe/releases
 lazy val log4catsVersion:        String = "0.4.0-M2"     //https://github.com/ChristopherDavenport/log4cats/releases

--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val `db-slick-psql` = subModule("db", "slick-psql")
 //*****************************************************************************
 //*****************************************************************************
 
-lazy val scalaCollCompatVersion: String = "2.1.1"        //https://github.com/scala/scala-collection-compat/releases
+lazy val scalaCollCompatVersion: String = "2.1.2"        //https://github.com/scala/scala-collection-compat/releases
 lazy val shapelessVersion:       String = "2.3.3"        //https://github.com/milessabin/shapeless/releases
 lazy val catsVersion:            String = "2.0.0-RC1"    //https://github.com/typelevel/cats/releases
 lazy val catsEffectVersion:      String = "2.0.0-M5"     //https://github.com/typelevel/cats-effect/releases

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -19,7 +19,7 @@ import sbt._
 import Keys._
 
 object Settings {
-  lazy val scala2_12:        String = "2.12.8"
+  lazy val scala2_12:        String = "2.12.9"
   lazy val scala2_13:        String = "2.13.0"
   lazy val mainScalaVersion: String = scala2_12
   lazy val organizationName: String = "com.busymachines"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,7 +21,7 @@ import Keys._
 object Settings {
   lazy val scala2_12:        String = "2.12.9"
   lazy val scala2_13:        String = "2.13.0"
-  lazy val mainScalaVersion: String = scala2_12
+  lazy val mainScalaVersion: String = scala2_13
   lazy val organizationName: String = "com.busymachines"
 
   lazy val pureharmHomepage: String = "https://github.com/busymachines/pureharm"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
       homepage                  := Some(url(pureharmHomepage)),
       scalaVersion              := mainScalaVersion,
       crossScalaVersions        := List(scala2_12, scala2_13),
-      addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.0"),  //https://github.com/oleg-py/better-monadic-for/releases
+      addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),  //https://github.com/oleg-py/better-monadic-for/releases
       addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"), //https://github.com/typelevel/kind-projector/releases
       scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => scala2_12Flags


### PR DESCRIPTION
- [x] cats to `2.0.0-RC1` from `2.0.0-M4`
- [x] scala-collection-compat to `2.1.2` from `2.1.1`
- [x] better-monadic-for to `0.3.1` from `0.3.0`
- [x] scala `2.12.9` from `2.12.8`
- [x] make scala `2.13.0` the main language in which the project compiles