### PR TITLE
breaking: reattempt

### DIFF
--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmTimedAttemptReattemptSyntaxOps.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmTimedAttemptReattemptSyntaxOps.scala
@@ -126,7 +126,7 @@ final class PureharmTimedAttemptReattemptSyntaxOps[F[_], A](val fa: F[A]) extend
     implicit
     F:     Sync[F],
     timer: Timer[F],
-  ): F[Attempt[A]] = {
+  ): F[A] = {
     PureharmTimedAttemptReattemptSyntaxOps.reattempt(errorLog)(retries, betweenRetries)(fa)
   }
 
@@ -140,7 +140,7 @@ final class PureharmTimedAttemptReattemptSyntaxOps[F[_], A](val fa: F[A]) extend
     implicit
     F:     Sync[F],
     timer: Timer[F],
-  ): F[Attempt[A]] = {
+  ): F[A] = {
     PureharmTimedAttemptReattemptSyntaxOps.reattempt(retries, betweenRetries)(fa)
   }
 }
@@ -263,8 +263,8 @@ object PureharmTimedAttemptReattemptSyntaxOps {
     betweenRetries: FiniteDuration,
   )(
     fa: F[A],
-  ): F[Attempt[A]] = {
-    this.timedReattempt(errorLog, NANOSECONDS)(retries, betweenRetries)(fa).map(_._2)
+  ): F[A] = {
+    this.timedReattempt(errorLog, NANOSECONDS)(retries, betweenRetries)(fa).map(_._2).rethrow
   }
 
   /**
@@ -275,8 +275,8 @@ object PureharmTimedAttemptReattemptSyntaxOps {
     betweenRetries: FiniteDuration,
   )(
     fa: F[A],
-  ): F[Attempt[A]] = {
-    this.timedReattempt(noLog(Sync[F]), NANOSECONDS)(retries, betweenRetries)(fa).map(_._2)
+  ): F[A] = {
+    this.timedReattempt(noLog(Sync[F]), NANOSECONDS)(retries, betweenRetries)(fa).map(_._2).rethrow
   }
 
   private def noLog[F[_]: Applicative]: (Throwable, String) => F[Unit] =

--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmTimedAttemptReattemptSyntaxOps.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmTimedAttemptReattemptSyntaxOps.scala
@@ -44,7 +44,7 @@ final class PureharmTimedAttemptReattemptSyntaxOps[F[_], A](val fa: F[A]) extend
     *   a more human friendly measurement as possible
     * @return
     *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both
+    *  times both success and failure case.
     */
   def timedAttempt(
     unit:       TimeUnit = MILLISECONDS,
@@ -68,7 +68,7 @@ final class PureharmTimedAttemptReattemptSyntaxOps[F[_], A](val fa: F[A]) extend
     *   a more human friendly measurement as possible
     * @return
     *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both.
+    *  times all successes and failures, and returns their sum.
     *  N.B.
     *  It only captures the latest failure, if it encounters one.
     */
@@ -112,10 +112,8 @@ final class PureharmTimedAttemptReattemptSyntaxOps[F[_], A](val fa: F[A]) extend
     *   N.B. you can also use [[FiniteDuration.toCoarsest]] to then obtain
     *   a more human friendly measurement as possible
     * @return
-    *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both.
-    *  N.B.
-    *  It only captures the latest failure, if it encounters one.
+    *   N.B.
+    *   It only captures the latest failure, if it encounters one.
     */
   def reattempt(
     errorLog: (Throwable, String) => F[Unit],
@@ -166,7 +164,7 @@ object PureharmTimedAttemptReattemptSyntaxOps {
     *   a more human friendly measurement as possible
     * @return
     *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both
+    *  times both success and failure case.
     */
   def timedAttempt[F[_], A](
     timeUnit: TimeUnit,
@@ -197,7 +195,7 @@ object PureharmTimedAttemptReattemptSyntaxOps {
     *   a more human friendly measurement as possible
     * @return
     *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both.
+    *  times all successes and failures, and returns their sum.
     *  N.B.
     *  It only captures the latest failure, if it encounters one.
     */
@@ -251,10 +249,8 @@ object PureharmTimedAttemptReattemptSyntaxOps {
     *   N.B. you can also use [[FiniteDuration.toCoarsest]] to then obtain
     *   a more human friendly measurement as possible
     * @return
-    *  Never fails and captures the failure of the ``fa`` within the [[Attempt]],
-    *  times both.
-    *  N.B.
-    *  It only captures the latest failure, if it encounters one.
+    *   N.B.
+    *   It only captures the latest failure, if it encounters one.
     */
   def reattempt[F[_]: Sync: Timer, A](
     errorLog: (Throwable, String) => F[Unit],


### PR DESCRIPTION
⚠️ BREAKING CHANGES ⚠️ 

Changes the return type of `.reattempt` methods from `F[Attempt[T]` to `F[T]`. Basically, to regain your previous semantics all you have to do is do a `.attempt` after your `reattempt`, or drop your `.rethrow` if that's what you were doing previously. It's really is that simple, and you truly gain 100% of the semantics just by applying the appropriate (pre-existing) combinators from `cats`. The simple fact that this is so easy just shows how fucking awesome pure FP is, I dare you to do this with futures without having to worry that you might screw stuff up.

The reason for this change is that it was quite unintuitive that this method would never fail by default. Empirically validated on two subjects in a totally super scientific study.