### PR TITLE
Release: 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,54 @@ New, better, iteration of our `busymachines-commons` — short for "pure harmony
 
 Currently the project is under heavy development, and is mostly driven by company needs until a stable version can be put out. At the end of the day this is a principled utility library that provides all glue to make web server development a breeze. It encourages users to use the "pureharm" style, for each application creating, for instance, your own "myapp.effects" package, which is easily created by mixing in traits provided by pureharm + your own domain specific stuff. 
 
+## sbt build
+Project published on `bintray`, so add the following to your build if you don't want to wait until maven central syncs:
+```scala
+resolvers ++= Seq(
+  Resolver.bintrayRepo("busymachines", "maven-releases"),
+  Resolver.bintrayRepo("busymachines", "maven-snapshots"),
+)
+```
+
+And then the available modules are:
+```scala
+val pureharmVersion: String = "0.0.2" //https://github.com/busymachines/pureharm/releases
+
+def pureharm(m: String): ModuleID = "com.busymachines" %% s"pureharm-$m" % pureharmVersion
+
+val pureharmCore:             ModuleID = pureharm("core")              withSources ()
+val pureharmCoreAnomaly:      ModuleID = pureharm("core-anomaly")      withSources ()
+val pureharmCorePhantom:      ModuleID = pureharm("core-phantom")      withSources ()
+val pureharmCoreIdentifiable: ModuleID = pureharm("core-identifiable") withSources ()
+val pureharmEffectsCats:      ModuleID = pureharm("effects-cats")      withSources ()
+val pureharmJsonCirce:        ModuleID = pureharm("json-circe")        withSources ()
+val pureharmConfig:           ModuleID = pureharm("config")            withSources ()
+
+val pureharmDBCore:       ModuleID = pureharm("db-core")        withSources ()
+val pureharmDBCoreFlyway: ModuleID = pureharm("db-core-flyway") withSources ()
+val pureharmDBSlick:      ModuleID = pureharm("db-slick")       withSources ()
+val pureharmDBPSQL:       ModuleID = pureharm("db-slick-psql")  withSources ()
+//------- OR --------
+
+libraryDependencies ++= Seq(
+  //pureharm-core brings in pureharm-core-anomaly, pureharm-core-phantom, and pureharm-core-identifiable.
+  "com.busymachines" %% s"pureharm-core"              % pureharmVersion,
+  "com.busymachines" %% s"pureharm-core-anomaly"      % pureharmVersion,
+  "com.busymachines" %% s"pureharm-core-phantom"      % pureharmVersion,
+  "com.busymachines" %% s"pureharm-core-identifiable" % pureharmVersion,
+  "com.busymachines" %% s"pureharm-effects-cats"      % pureharmVersion,
+  "com.busymachines" %% s"pureharm-json-circe"        % pureharmVersion,
+  "com.busymachines" %% s"pureharm-config"            % pureharmVersion,
+  "com.busymachines" %% s"pureharm-db-core"           % pureharmVersion,
+  "com.busymachines" %% s"pureharm-db-core-flyway"    % pureharmVersion,
+  "com.busymachines" %% s"pureharm-db-slick"          % pureharmVersion,
+  "com.busymachines" %% s"pureharm-db-slick-psql"     % pureharmVersion,
+)
+```
+
+## Usage
+Under construction. See [release notes](https://github.com/busymachines/pureharm/releases) and tests for examples.
+
 ## Copyright and License
 
 All code is available to you under the Apache 2.0 license, available at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) and also in the [LICENSE](./LICENSE) file.

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ addCommandAlias("rebuild-update", ";clean;update;compile;Test/compile")
 addCommandAlias("ci", ";scalafmtCheck;rebuild-update;test")
 addCommandAlias("ci-quick", ";scalafmtCheck;build;test")
 addCommandAlias("doLocal", ";clean;update;compile;publishLocal")
-addCommandAlias("doRelease", ";rebuild-update;publishSigned;sonatypeRelease")
+addCommandAlias("doRelease", ";rebuild-update;publish;bintrayRelease")
 
 addCommandAlias("lint", ";scalafixEnable;rebuild;scalafix;scalafmtAll")
 
@@ -66,7 +66,7 @@ lazy val root = Project(id = "pureharm", base = file("."))
 lazy val `core-deps` = `core-anomaly-deps` ++ `core-phantom-deps` ++ `core-identifiable-deps`
 
 lazy val core = project
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-core",
@@ -90,7 +90,7 @@ lazy val `core-anomaly-deps` = Seq(
 )
 
 lazy val `core-anomaly` = subModule("core", "anomaly")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `core-anomaly-deps`.distinct,
@@ -104,7 +104,7 @@ lazy val `core-phantom-deps` = Seq(
 )
 
 lazy val `core-phantom` = subModule("core", "phantom")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `core-phantom-deps`.distinct,
@@ -118,7 +118,7 @@ lazy val `core-identifiable-deps` = `core-phantom-deps` ++ Seq(
 )
 
 lazy val `core-identifiable` = subModule("core", "identifiable")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `core-identifiable-deps`.distinct,
@@ -142,7 +142,7 @@ lazy val `effects-cats-deps` = `core-phantom-deps` ++ Seq(
 ) ++ cats
 
 lazy val `effects-cats` = project
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-effects-cats",
@@ -162,7 +162,7 @@ lazy val `json-circe-deps` = `effects-cats-deps` ++ Seq(
 ) ++ circe
 
 lazy val `json-circe` = project
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-json-circe",
@@ -185,7 +185,7 @@ lazy val `config-deps` = `core-anomaly-deps` ++ `core-phantom-deps` ++ `effects-
 )
 
 lazy val `config` = project
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     name := "pureharm-config",
@@ -231,7 +231,7 @@ lazy val `db-core-deps` = `core-deps` ++ `effects-cats-deps` ++ `config-deps` ++
 )
 
 lazy val `db-core` = subModule("db", "core")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `db-core-deps`.distinct,
@@ -257,7 +257,7 @@ lazy val `db-core-flyway-deps` = `core-deps` ++ `effects-cats-deps` ++ `config-d
 )
 
 lazy val `db-core-flyway` = subModule("db", "core-flyway")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `db-core-flyway-deps`.distinct,
@@ -282,7 +282,7 @@ lazy val `db-slick-deps` = `core-deps` ++ `effects-cats-deps` ++ `config-deps` +
 ) ++ dbSlick
 
 lazy val `db-slick` = subModule("db", "slick")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `db-slick-deps`.distinct,
@@ -316,7 +316,7 @@ lazy val `db-slick-psql-deps` =
   )
 
 lazy val `db-slick-psql` = subModule("db", "slick-psql")
-  .settings(PublishingSettings.sonatypeSettings)
+  .settings(PublishingSettings.bintraySettings)
   .settings(Settings.commonSettings)
   .settings(
     libraryDependencies ++= `db-slick-psql-deps`.distinct,

--- a/effects-cats/src/test/scala/busymachines/pureharm/effects/pools/test/PoolsResourceTest.scala
+++ b/effects-cats/src/test/scala/busymachines/pureharm/effects/pools/test/PoolsResourceTest.scala
@@ -84,14 +84,14 @@ final class PoolsResourceTest extends AnyFunSuite {
   private def testPools[F[_]: Sync: ContextShift]: Resource[F, PHTestPools[F]] =
     for {
       nrOfCPUs <- Pools.availableCPUs[F]
-      _        <- println(s"starting test w/ #of CPUs: $nrOfCPUs").pure[Resource[F, ?]]
+      _        <- println(s"starting test w/ #of CPUs: $nrOfCPUs").pure[Resource[F, *]]
 
       dbBlockingCT    <- Pools.cached[F](dbBlocTP)
       dbConnectFT     <- Pools.fixed[F](dbConnTP, nrOfCPUs * 2)
       httpFT          <- Pools.fixed[F](httpTP, nrOfCPUs)
       blockingCT      <- Pools.cached[F](blockingTP)
       singleST        <- Pools.singleThreaded[F](singleTP)
-      blockingShifter <- BlockingShifter.fromExecutionContext[F](blockingCT).pure[Resource[F, ?]]
+      blockingShifter <- BlockingShifter.fromExecutionContext[F](blockingCT).pure[Resource[F, *]]
     } yield new PHTestPools[F](
       dbBlocking      = dbBlockingCT,
       dbConnection    = dbConnectFT,

--- a/json-circe/src/main/scala/busymachines/pureharm/internals/json/PureharmJsonSyntax.scala
+++ b/json-circe/src/main/scala/busymachines/pureharm/internals/json/PureharmJsonSyntax.scala
@@ -66,11 +66,11 @@ object PureharmJsonSyntax {
       JsonDecoding.decodeAs[A](js)
     }
 
-    def noSpacesNoNulls: String = js.pretty(PrettyJson.noSpacesNoNulls)
+    def noSpacesNoNulls: String = js.printWith(PrettyJson.noSpacesNoNulls)
 
-    def spaces2NoNulls: String = js.pretty(PrettyJson.spaces2NoNulls)
+    def spaces2NoNulls: String = js.printWith(PrettyJson.spaces2NoNulls)
 
-    def spaces4NoNulls: String = js.pretty(PrettyJson.spaces4NoNulls)
+    def spaces4NoNulls: String = js.printWith(PrettyJson.spaces4NoNulls)
   }
 
 }

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -15,72 +15,54 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-import sbt._
-import Keys._
-import com.typesafe.sbt.SbtPgp.autoImportImpl._
-import xerial.sbt.Sonatype.SonatypeKeys._
+  import sbt._
+  import Keys._
+  import com.typesafe.sbt.SbtPgp.autoImportImpl._
+  import bintray.BintrayKeys._
+  
+  /**
+    * Publishing is done to bintray — to this org:
+    * https://bintray.com/busymachines/maven-releases
+    *
+    * To set up bintray, just look at a combination of two docs:
+    * https://github.com/sbt/sbt-bintray and a more user friendly:
+    * http://queirozf.com/entries/publishing-an-sbt-project-onto-bintray-an-example
+    *
+    * TL;DR:
+    * 1. create bintray account: https://bintray.com/
+    * 2. request to be added as a member to busymachines organization : https://bintray.com/busymachines
+    * 3. set your ~/.bintray/.credentials file to contain:
+    * {{{
+    * realm = Bintray API Realm
+    * host = api.bintray.com
+    * user = ${username that has publishing access to busymachines bintray org linked above}
+    * password = ${get password by generating an API Key from the bintray UI}
+    * }}}
+    *
+    * N.B. for historical purposes
+    * For sync-ing to maven central you need to setup bintray to communicate via sonatype with
+    * maven central. Quite complicated honestly. Should already be set-up at this point.
+    * Anyway, the issue that gives you access to sonatype via which you can sync to maven central is here:
+    * The username and password are the same as those to the Sonatype JIRA account.
+    * https://issues.sonatype.org/browse/OSSRH-33718
+    */
+  object PublishingSettings {
+  
+    def bintraySettings: Seq[Setting[_]] = Seq(
+      licenses                := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+      bintrayOrganization     := Some("busymachines"),
+      bintrayRepository       := { if (isSnapshot.value) "maven-snapshots" else "maven-releases" },
+      bintrayReleaseOnPublish := false,
+      bintrayPackageLabels    := Seq("scala", "pureharm-aws", "busymachines"),
+    )
 
-/**
-  * All instructions for publishing to sonatype can be found on the sbt-plugin page:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html
-  *
-  * and some here:
-  *
-  * https://github.com/xerial/sbt-sonatype
-  *
-  * VERY IMPORTANT!!! You need to add credentials as described here:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#Second+-+Configure+Sonatype+integration
-  *
-  * The username and password are the same as those to the Sonatype JIRA account.
-  * https://issues.sonatype.org/browse/OSSRH-33718
-  *
-  * And then you need to ensure PGP keys to sign the maven artifacts:
-  * http://www.scala-sbt.org/release/docs/Using-Sonatype.html#PGP+Tips%E2%80%99n%E2%80%99tricks
-  * Which means that you need to have PGP installed
-  *
-  * To avoid pushing sensitive information to github you must put all PGP related things in your local configs:
-  * as described here:
-  *
-  * https://github.com/sbt/sbt-pgp/issues/69
-  */
-object PublishingSettings {
+    def noPublishSettings: Seq[Setting[_]] = Seq(
+      publish                := {},
+      publishLocal           := {},
+      skip in publishLocal   := true,
+      skip in publish        := true,
+      skip in bintrayRelease := true,
+      publishArtifact        := false,
+    )
 
-  def sonatypeSettings: Seq[Setting[_]] = Seq(
-    useGpg                     := true,
-    sonatypeProfileName        := Settings.organizationName,
-    publishArtifact in Compile := true,
-    publishArtifact in Test    := false,
-    publishMavenStyle          := true,
-    pomIncludeRepository       := (_ => false),
-    publishTo := Option {
-      if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-      else
-        Opts.resolver.sonatypeStaging
-    },
-    licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-    scmInfo := Option(
-      ScmInfo(
-        url("https://github.com/busymachines/pureharm"),
-        "scm:git@github.com:busymachines/pureharm.git",
-      ),
-    ),
-    developers := List(
-      Developer(
-        id    = "lorandszakacs",
-        name  = "Lorand Szakacs",
-        email = "lorand.szakacs@busymachines.com",
-        url   = url("https://github.com/lorandszakacs"),
-      ),
-    ),
-  )
-
-  def noPublishSettings: Seq[Setting[_]] = Seq(
-    publish              := {},
-    publishLocal         := {},
-    skip in publishLocal := true,
-    skip in publish      := true,
-    publishArtifact      := false,
-  )
-
-}
+  }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,6 +39,10 @@ object Settings {
         case Some((2, 13)) => scala2_13Flags
         case _             => Seq.empty
       }) ++ betterForPluginCompilerFlags,
+      resolvers ++= Seq(
+        Resolver.bintrayRepo("busymachines", "maven-releases"),
+        Resolver.bintrayRepo("busymachines", "maven-snapshots"),
+      ),
     )
 
   /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,14 +16,15 @@
   * limitations under the License.
   */
 /**
-  * Helps us publish the artifacts to sonatype, which in turn
-  * pushes to maven central. Please follow instructions of setting
-  * up as described in:
-  * http://busymachines.github.io/busymachines-commons/docs/publishing-artifacts.html
+  * Helps us publish the artifacts to bintray, which in turn
+  * pushes to maven central.
+  * 
+  * See this guide for help:
+  * http://queirozf.com/entries/publishing-an-sbt-project-onto-bintray-an-example
   *
-  * https://github.com/xerial/sbt-sonatype/releases
+  * https://github.com/sbt/sbt-bintray/releases
   */
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.0") //https://github.com/xerial/sbt-sonatype/releases
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
 /**
   *

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2"
+version in ThisBuild := "0.0.3-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2-SNAPSHOT"
+version in ThisBuild := "0.0.2"


### PR DESCRIPTION
🎉Cross compiled for scala `2.12` and `2.13` 🎉

Depends on stable versions of all libraries (each for the appropriate module, of course):
- [x] cats-core `2.0.0`
- [x] cats-effect `2.0.0`
- [x] circe `0.12.1`
- [x] pureconfig `0.11.1`
- [x] slick `3.3.2`
- [x] flyway `6.0.2`
- [x] postgresql JDBC `42.2.6`
- [x] hikariCP `3.3.1`