### PR TITLE
Feature: IO companion ops

### DIFF
--- a/effects-cats/src/test/scala/busymachines/pureharm/effects/test/PureharmSyntaxTest.scala
+++ b/effects-cats/src/test/scala/busymachines/pureharm/effects/test/PureharmSyntaxTest.scala
@@ -370,7 +370,7 @@ final class PureharmSyntaxTest extends AnyFunSpec {
       }
     }
 
-    describe("purifyIn[...]") {
+    describe("liftTo[...]") {
       implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
       test("... IO") {
@@ -407,6 +407,124 @@ final class PureharmSyntaxTest extends AnyFunSpec {
         assert(io.unsafeRunSync() == 42, "value of suspended future")
         assert(sideEffect == 42, "after unsafeRunSync side effect should be applied")
       }
+    }
+  }
+
+  describe("IO syntax") {
+    describe("traversals") {
+
+      describe("IO.serialize") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[List[Unit]] = IO.serialize(input) { _ =>
+            IO {
+              sideEffect = 42
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
+      describe("IO.serialize_") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[Unit] = IO.serialize_(input) { _ =>
+            IO {
+              sideEffect = 42
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
+      describe("IO.traverse") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[List[Unit]] = IO.traverse(input) { _ =>
+            IO {
+              sideEffect = 42
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
+      describe("IO.traverse_") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[Unit] = IO.traverse_(input) { _ =>
+            IO {
+              sideEffect = 42
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
+      describe("IO.sequence") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[List[Unit]] = IO.sequence {
+            input.map { _ =>
+              IO {
+                sideEffect = 42
+              }
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
+      describe("IO.sequence_") {
+
+        test("empty list") {
+          val input: List[Int] = List()
+
+          var sideEffect: Int = 0
+
+          val eventualResult: IO[Unit] = IO.sequence_ {
+            input.map { _ =>
+              IO {
+                sideEffect = 42
+              }
+            }
+          }
+
+          eventualResult.unsafeRunSync()
+          assert(sideEffect == 0, "nothing should have happened")
+        }
+      }
+
     }
   }
 }

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -18,7 +18,6 @@
 import sbt._
 import sbt.Keys._
 import xerial.sbt.Sonatype.SonatypeKeys._
-import xerial.sbt.Sonatype._
 
 /**
   * All instructions for publishing to sonatype can be found on the sbt-plugin page:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 #https://github.com/sbt/sbt/releases
-sbt.version=1.3.0
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -49,7 +49,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11") //https://github.co
   * https://github.com/scalameta/sbt-scalafmt/releases
   *
   */
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6") //https://github.com/scalameta/sbt-scalafmt/releases
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.7") //https://github.com/scalameta/sbt-scalafmt/releases
 
 /**
   * Refactoring/linting tool for scala.


### PR DESCRIPTION
Add some ops on the IO companion object to mirror what exists on the companion of `Future`. This makes a search + replace of `Future` w/ `IO` in legacy code easier 😄 — 🎉 