### PR TITLE
[db-slick] Fix tests in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -326,6 +326,10 @@ lazy val `db-slick-psql` = subModule("db", "slick-psql")
   .settings(CompilerSettings.commonSettings)
   .settings(
     libraryDependencies ++= `db-slick-psql-deps`.distinct,
+    //required because JDBC screws up classloading somehow,
+    //and PSQL driver is not found for certain tests that connect to DB.
+    //no idea why
+    Test / fork := true,
   )
   .dependsOn(
     `core`,


### PR DESCRIPTION
Problem:

When run in SBT, we get the following failure in tests:
```
[info] TransactorTest:
[info] - creates the transactor and the session connection is open from the start *** FAILED ***
[info]   java.lang.RuntimeException: Failed to get driver instance for jdbcUrl=jdbc:postgresql://localhost:20010/pureharm_test
[info]   at com.zaxxer.hikari.util.DriverDataSource.<init>(DriverDataSource.java:114)
[info]   at com.zaxxer.hikari.pool.PoolBase.initializeDataSource(PoolBase.java:321)
[info]   at com.zaxxer.hikari.pool.PoolBase.<init>(PoolBase.java:110)
[info]   at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:108)
[info]   at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
[info]   at busymachines.pureharm.internals.dbslick.HikariTransactorImpl$.$anonfun$unsafeCreate$1(HikariTransactorImpl.scala:119)
[info]   at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
[info]   at cats.effect.internals.IORunLoop$.start(IORunLoop.scala:34)
[info]   at cats.effect.internals.IOBracket$.$anonfun$apply$1(IOBracket.scala:44)
[info]   at cats.effect.internals.IOBracket$.$anonfun$apply$1$adapted(IOBracket.scala:34)
[info]   ...
[info]   Cause: java.sql.SQLException: No suitable driver
[info]   at java.sql/java.sql.DriverManager.getDriver(DriverManager.java:298)
[info]   at com.zaxxer.hikari.util.DriverDataSource.<init>(DriverDataSource.java:106)
[info]   at com.zaxxer.hikari.pool.PoolBase.initializeDataSource(PoolBase.java:321)
[info]   at com.zaxxer.hikari.pool.PoolBase.<init>(PoolBase.java:110)
[info]   at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:108)
[info]   at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
[info]   at busymachines.pureharm.internals.dbslick.HikariTransactorImpl$.$anonfun$unsafeCreate$1(HikariTransactorImpl.scala:119)
[info]   at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
[info]   at cats.effect.internals.IORunLoop$.start(IORunLoop.scala:34)
[info]   at cats.effect.internals.IOBracket$.$anonfun$apply$1(IOBracket.scala:44)
[info]   ...
```
No idea why JDBC would do this, but DB tests never fail in Intellij, and they do in sbt. So intuition tells me that it has to do with the JVM in which they are run. And lo' and behold, I was right.