### PR TITLE
Update: cats 2.2.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -418,7 +418,7 @@ lazy val testkit = project
 
 lazy val scalaCollCompatVersion: String = "2.1.6"    //https://github.com/scala/scala-collection-compat/releases
 lazy val shapelessVersion:       String = "2.4.0-M1" //https://github.com/milessabin/shapeless/releases
-lazy val catsVersion:            String = "2.1.1"    //https://github.com/typelevel/cats/releases
+lazy val catsVersion:            String = "2.2.0-RC1"    //https://github.com/typelevel/cats/releases
 lazy val catsEffectVersion:      String = "2.1.3"    //https://github.com/typelevel/cats-effect/releases
 lazy val fs2Version:             String = "2.4.2"    //https://github.com/functional-streams-for-scala/fs2/releases
 lazy val circeVersion:           String = "0.13.0"   //https://github.com/circe/circe/releases

--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmSyntax.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/PureharmSyntax.scala
@@ -151,8 +151,6 @@ object PureharmSyntax {
     }
   }
 
-  final private val singletonUnitAttempt: Attempt[Unit] = Right[Throwable, Unit](())
-
   /**
     * This helps mimick operations on the ``Attempt`` using
     * the standard ``Either`` companion, thus making all
@@ -165,8 +163,6 @@ object PureharmSyntax {
     def pure[A](a: A): Attempt[A] = Right[Throwable, A](a)
 
     def raiseError[A](t: Throwable): Attempt[A] = Left[Throwable, A](t)
-
-    def unit: Attempt[Unit] = singletonUnitAttempt
   }
 
   //--------------------------- TRY ---------------------------

--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/catsAliases.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/catsAliases.scala
@@ -32,7 +32,9 @@ private[pureharm] trait CatsImplicitsAll extends CatsSyntaxAliasesCore with Cats
 private[pureharm] trait CatsSyntaxAliasesCore
   extends syntax.AllSyntax with syntax.AllSyntaxBinCompat0 with syntax.AllSyntaxBinCompat1
   with syntax.AllSyntaxBinCompat2 with syntax.AllSyntaxBinCompat3 with syntax.AllSyntaxBinCompat4
-  with instances.AllInstances with instances.AllInstancesBinCompat0 with instances.AllInstancesBinCompat1
-  with instances.AllInstancesBinCompat2 with instances.AllInstancesBinCompat3
+  with syntax.AllSyntaxBinCompat5 with syntax.AllSyntaxBinCompat6 with instances.AllInstances
+  with instances.AllInstancesBinCompat0 with instances.AllInstancesBinCompat1 with instances.AllInstancesBinCompat2
+  with instances.AllInstancesBinCompat3 with instances.AllInstancesBinCompat4 with instances.AllInstancesBinCompat5
+  with instances.AllInstancesBinCompat6
 
 private[pureharm] trait CatsSyntaxAliasesEffect extends AllCatsEffectSyntax

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -71,7 +71,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0") //https://github.com/sc
   *
   * }}}
   */
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.18") //https://github.com/scalacenter/scalafix/releases
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17") //https://github.com/scalacenter/scalafix/releases
 
 /**
   * https://github.com/lampepfl/dotty/releases


### PR DESCRIPTION
Use cats `2.2.0-RC1`, because of the moving around of implicits for scala.Predef types, downstream projects now have consistently lower compile times 🥳 .