### PR TITLE
Feature: configurable config source

### DIFF
--- a/config/src/main/scala/busymachines/pureharm/config/anomalies.scala
+++ b/config/src/main/scala/busymachines/pureharm/config/anomalies.scala
@@ -30,7 +30,7 @@ final case class ConfigReadingAnomaly(c: ConfigReaderFailure)
   override val id: AnomalyID = ConfigReadingAnomalyID
 
   override val parameters: Anomaly.Parameters = {
-    val orig: Anomaly.Parameters = Anomaly.Parameters(
+    val orig: Anomaly.Parameters = super.parameters ++ Anomaly.Parameters(
       "reason" -> c.description
     )
     val loc = c.location.map(l => "location" -> l.description: (String, Anomaly.Parameter))
@@ -51,6 +51,19 @@ final case class ConfigAggregateAnomalies(cs: ConfigReaderFailures, namespace: O
   def withNamespace(ns: String): ConfigAggregateAnomalies = this.copy(namespace = Option(ns))
 }
 
+final case class ConfigSourceLoadingAnomaly(cause: Throwable)
+  extends InvalidInputAnomaly(s"Failed to load config because: ${cause.toString}", causedBy = Option(cause)) {
+
+  override val id: AnomalyID = ConfigSourceLoadingAnomalyID
+
+  override val parameters: Anomaly.Parameters = {
+    super.parameters ++ Anomaly.Parameters(
+      "stackTrace" -> cause.getStackTrace.map(_.toString).toSeq
+    )
+  }
+}
+
 //----------------------------- config ----------------------------
-case object ConfigReadingAnomalyID     extends AnomalyID { override val name: String = "ph-config-001" }
-case object ConfigAggregateAnomaliesID extends AnomalyID { override val name: String = "ph-config-002" }
+case object ConfigReadingAnomalyID       extends AnomalyID { override val name: String = "ph-config-001" }
+case object ConfigAggregateAnomaliesID   extends AnomalyID { override val name: String = "ph-config-002" }
+case object ConfigSourceLoadingAnomalyID extends AnomalyID { override val name: String = "ph-config-003" }

--- a/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
@@ -17,6 +17,7 @@
   */
 package busymachines.pureharm.internals.config
 
+import busymachines.pureharm.anomaly.NotImplementedCatastrophe
 import busymachines.pureharm.config.ConfigAggregateAnomalies
 import busymachines.pureharm.effects._
 import busymachines.pureharm.effects.implicits._
@@ -64,13 +65,26 @@ trait ConfigLoader[Config] {
     */
   implicit def configReader: ConfigReader[Config]
 
-  def default[F[_]: Sync]: F[Config]
+  @scala.deprecated(
+    "Usage of this is discouraged, please just explicitly use .fromNamespace, or write your own. Will be removed, in 0.0.7, and then you can just drop your override modifier",
+    "0.0.6-M4",
+  )
+  def default[F[_]: Sync]: F[Config] =
+    Sync[F].raiseError(
+      NotImplementedCatastrophe(
+        "Config.default now defaults to non-implemented, please use something else, or roll your own"
+      )
+    )
 
   /**
     * Override in subtypes when needed
     */
   def fromNamespace[F[_]: Sync](namespace: String): F[Config] = this.load(namespace)
 
+  @scala.deprecated(
+    "Usage of this is discouraged, please just explicitly use .fromNamespaceR, or write your own. Will be removed, in 0.0.7, and then you can just drop your override modifier",
+    "0.0.6-M4",
+  )
   final def defaultR[F[_]: Sync]: Resource[F, Config] = Resource.liftF(default)
 
   final def fromNamespaceR[F[_]: Sync](namespace: String): Resource[F, Config] =

--- a/config/src/test/resources/not-a-conf.txt
+++ b/config/src/test/resources/not-a-conf.txt
@@ -1,0 +1,10 @@
+pureharm.config.test {
+  phantom-int = 81234
+  phantom-string = "phantom-not-a-config"
+  phantom-boolean = true
+  phantom-list = [1, 2, 3]
+  phantom-set = ["value1", "value1", "value2"]
+  phantom-finite-duration = 10 minutes
+  phantom-duration = 10 minutes
+  safe-phantom-int = 123
+}

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfig.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfig.scala
@@ -42,6 +42,6 @@ private[test] object PureharmTestConfig extends ConfigLoader[PureharmTestConfig]
   implicit override val configReader: ConfigReader[PureharmTestConfig] =
     semiauto.deriveReader[PureharmTestConfig]
 
-  override def default[F[_]: Sync]: F[PureharmTestConfig] =
+  def testConfig[F[_]: Sync]: F[PureharmTestConfig] =
     this.load("pureharm.config.test")
 }

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
@@ -1,0 +1,56 @@
+/**
+  * Copyright (c) 2019 BusyMachines
+  *
+  * See company homepage at: https://www.busymachines.com/
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package busymachines.pureharm.config.test
+
+import busymachines.pureharm.config.ConfigSourceLoadingAnomaly
+import busymachines.pureharm.effects._
+import busymachines.pureharm.testkit.PureharmTest
+
+import scala.concurrent.duration._
+
+/**
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 16 Jun 2019
+  */
+final class PureharmTestConfigFromDefaultSourceTest extends PureharmTest {
+
+  test("load config from correct custom path") {
+    val correct = new PureharmTestConfigLoaderFromSource("not-a-conf.txt")
+    for {
+      read <- correct.fromNamespace[IO]("pureharm.config.test")
+    } yield assert(
+      read === PureharmTestConfig(
+        PhantomInt(81234),
+        PhantomString("phantom-not-a-config"),
+        PhantomBoolean(true),
+        PhantomList(List(1, 2, 3)),
+        PhantomSet(Set("value1", "value2")),
+        PhantomFiniteDuration(10.minutes),
+        PhantomDuration(10.minutes),
+        SafePhantomInt.unsafe(123),
+      )
+    )
+  }
+
+  test("load config from incorrect custom path") {
+    val incorrectSource = new PureharmTestConfigLoaderFromSource("please-no-NPE.txt")
+    for {
+      attempt <- incorrectSource.fromNamespace[IO]("pureharm.config.test").attempt
+    } yield assertFailure[ConfigSourceLoadingAnomaly](attempt)
+  }
+}

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigLoaderFromSource.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigLoaderFromSource.scala
@@ -15,23 +15,21 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-package busymachines.pureharm.config
-
-import busymachines.pureharm.internals.config
+package busymachines.pureharm.config.test
 
 /**
   * @author Lorand Szakacs, https://github.com/lorandszakacs
   * @since 16 Jun 2019
   */
-trait PureconfigAllTypeDefinitions {
-  final type ConfigReader[A] = pureconfig.ConfigReader[A]
-  final val ConfigReader: pureconfig.ConfigReader.type = pureconfig.ConfigReader
-  final type ConfigWriter[A] = pureconfig.ConfigWriter[A]
-  final val ConfigWriter: pureconfig.ConfigWriter.type = pureconfig.ConfigWriter
+import busymachines.pureharm.config._
+import busymachines.pureharm.effects._
+import busymachines.pureharm.effects.implicits._
 
-  final type ConfigSource = pureconfig.ConfigSource
-  final val ConfigSource: pureconfig.ConfigSource.type = pureconfig.ConfigSource
+private[test] class PureharmTestConfigLoaderFromSource(filePath: String) extends ConfigLoader[PureharmTestConfig] {
 
-  final type ConfigLoader[A] = config.ConfigLoader[A]
-  final val semiauto: pureconfig.generic.semiauto.type = pureconfig.generic.semiauto
+  override def configSource[F[_]](implicit F: Sync[F]): F[ConfigSource] =
+    F.delay(java.nio.file.Paths.get(this.getClass.getClassLoader.getResource(filePath).toURI))
+      .map(ConfigSource.file)
+
+  override def configReader: ConfigReader[PureharmTestConfig] = PureharmTestConfig.configReader
 }

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
@@ -32,7 +32,7 @@ final class PureharmTestConfigTest extends PureharmTest {
   test("load config with phantom common types") {
 
     for {
-      read <- PureharmTestConfig.default[IO]
+      read <- PureharmTestConfig.testConfig[IO]
     } yield assert(
       read === PureharmTestConfig(
         PhantomInt(42),

--- a/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/FlywayConfig.scala
+++ b/db/submodules/core-flyway/src/main/scala/busymachines/pureharm/db/flyway/FlywayConfig.scala
@@ -77,8 +77,6 @@ final case class FlywayConfig(
 
 object FlywayConfig extends ConfigLoader[FlywayConfig] with internals.FlywayConfigFluentApi {
 
-  import busymachines.pureharm.effects._
-
   override def defaultConfig: FlywayConfig = FlywayConfig()
 
   override def withLocations(locations: MigrationLocation*):      FlywayConfig =
@@ -109,8 +107,6 @@ object FlywayConfig extends ConfigLoader[FlywayConfig] with internals.FlywayConf
 
   implicit override val configReader: ConfigReader[FlywayConfig] =
     alternateRepresentationReader.orElse(semiauto.deriveReader[FlywayConfig])
-
-  override def default[F[_]: Sync]: F[FlywayConfig] = this.load[F]("pureharm.db.migration")
 
   /**
     * This allows us to specify a single string, instead of a list of strings,

--- a/db/submodules/core/src/main/scala/busymachines/pureharm/db/DBConnectionConfig.scala
+++ b/db/submodules/core/src/main/scala/busymachines/pureharm/db/DBConnectionConfig.scala
@@ -38,11 +38,7 @@ final case class DBConnectionConfig(
 import busymachines.pureharm.config._
 
 object DBConnectionConfig extends ConfigLoader[DBConnectionConfig] {
-  import busymachines.pureharm.effects.Sync
   import busymachines.pureharm.config.implicits._
 
   implicit override def configReader: ConfigReader[DBConnectionConfig] = semiauto.deriveReader[DBConnectionConfig]
-
-  override def default[F[_]: Sync]: F[DBConnectionConfig] =
-    this.load("pureharm.db.connection")
 }


### PR DESCRIPTION
New features:
- `...config.ConfigLoader` now can take a custom config source by `override def configSource[F[_]: Sync]: F[ConfigSource]`

Deprecations:
- `...config.ConfigLoader.default` is now deprecated and has default `NotImplemented` error value. Usage of this pattern is now discouraged, will be removed in future releases, and then you can keep same behavior by dropping the override modifier in your code.