### PR TITLE
Feature: more type aliases

### DIFF
--- a/config/src/main/scala/busymachines/pureharm/config/PureconfigAllTypeDefinitions.scala
+++ b/config/src/main/scala/busymachines/pureharm/config/PureconfigAllTypeDefinitions.scala
@@ -34,4 +34,13 @@ trait PureconfigAllTypeDefinitions {
 
   final type ConfigLoader[A] = config.ConfigLoader[A]
   final val semiauto: pureconfig.generic.semiauto.type = pureconfig.generic.semiauto
+
+  final type ConfigAggregateAnomalies = config.ConfigAggregateAnomalies
+  final val ConfigAggregateAnomalies: config.ConfigAggregateAnomalies.type = config.ConfigAggregateAnomalies
+
+  final type ConfigReadingAnomaly = config.ConfigReadingAnomaly
+  final val ConfigReadingAnomaly: config.ConfigReadingAnomaly.type = config.ConfigReadingAnomaly
+
+  final type ConfigSourceLoadingAnomaly = config.ConfigSourceLoadingAnomaly
+  final val ConfigSourceLoadingAnomaly: config.ConfigSourceLoadingAnomaly.type = config.ConfigSourceLoadingAnomaly
 }

--- a/config/src/main/scala/busymachines/pureharm/config/PureconfigAllTypeDefinitions.scala
+++ b/config/src/main/scala/busymachines/pureharm/config/PureconfigAllTypeDefinitions.scala
@@ -43,4 +43,24 @@ trait PureconfigAllTypeDefinitions {
 
   final type ConfigSourceLoadingAnomaly = config.ConfigSourceLoadingAnomaly
   final val ConfigSourceLoadingAnomaly: config.ConfigSourceLoadingAnomaly.type = config.ConfigSourceLoadingAnomaly
+
+  final type ConfigReaderFailure = pureconfig.error.ConfigReaderFailure
+  final type ConvertFailure      = pureconfig.error.ConvertFailure
+  final type ThrowableFailure    = pureconfig.error.ThrowableFailure
+  final type CannotRead          = pureconfig.error.CannotRead
+  final type CannotReadFile      = pureconfig.error.CannotReadFile
+  final type CannotReadUrl       = pureconfig.error.CannotReadUrl
+  final type CannotReadResource  = pureconfig.error.CannotReadResource
+  final type CannotParse         = pureconfig.error.CannotParse
+
+  final val ConvertFailure:     pureconfig.error.ConvertFailure.type     = pureconfig.error.ConvertFailure
+  final val ThrowableFailure:   pureconfig.error.ThrowableFailure.type   = pureconfig.error.ThrowableFailure
+  final val CannotReadFile:     pureconfig.error.CannotReadFile.type     = pureconfig.error.CannotReadFile
+  final val CannotReadUrl:      pureconfig.error.CannotReadUrl.type      = pureconfig.error.CannotReadUrl
+  final val CannotReadResource: pureconfig.error.CannotReadResource.type = pureconfig.error.CannotReadResource
+  final val CannotParse:        pureconfig.error.CannotParse.type        = pureconfig.error.CannotParse
+
+  final type ConfigReaderFailures     = pureconfig.error.ConfigReaderFailures
+  final type ConfigReaderException[T] = pureconfig.error.ConfigReaderException[T]
+  final type ConfigValueLocation      = pureconfig.error.ConfigValueLocation
 }

--- a/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/ConfigLoader.scala
@@ -18,7 +18,6 @@
 package busymachines.pureharm.internals.config
 
 import busymachines.pureharm.anomaly.NotImplementedCatastrophe
-import busymachines.pureharm.config.{ConfigAggregateAnomalies, ConfigSourceLoadingAnomaly}
 import busymachines.pureharm.effects._
 import busymachines.pureharm.effects.implicits._
 import pureconfig._

--- a/config/src/main/scala/busymachines/pureharm/internals/config/anomalies.scala
+++ b/config/src/main/scala/busymachines/pureharm/internals/config/anomalies.scala
@@ -15,7 +15,7 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-package busymachines.pureharm.config
+package busymachines.pureharm.internals.config
 
 import busymachines.pureharm.anomaly._
 import pureconfig.error.{ConfigReaderFailure, ConfigReaderFailures}

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigFromDefaultSourceTest.scala
@@ -17,8 +17,8 @@
   */
 package busymachines.pureharm.config.test
 
-import busymachines.pureharm.config.ConfigSourceLoadingAnomaly
 import busymachines.pureharm.effects._
+import busymachines.pureharm.internals.config.ConfigSourceLoadingAnomaly
 import busymachines.pureharm.testkit.PureharmTest
 
 import scala.concurrent.duration._

--- a/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
+++ b/config/src/test/scala/busymachines/pureharm/config/test/PureharmTestConfigTest.scala
@@ -17,10 +17,9 @@
   */
 package busymachines.pureharm.config.test
 
-import busymachines.pureharm.config._
-
 import scala.concurrent.duration._
 import busymachines.pureharm.effects._
+import busymachines.pureharm.internals.config.ConfigAggregateAnomalies
 import busymachines.pureharm.testkit.PureharmTest
 
 /**

--- a/core/src/main/scala/busymachines/pureharm/PureharmCoreTypeDefinitions.scala
+++ b/core/src/main/scala/busymachines/pureharm/PureharmCoreTypeDefinitions.scala
@@ -34,4 +34,10 @@ trait PureharmCoreTypeDefinitions {
   final type PhantomType[T]        = phantom.PhantomType[T]
   final type SafePhantomType[E, T] = phantom.SafePhantomType[E, T]
   final type AttemptPhantomType[T] = phantom.SafePhantomType[Throwable, T]
+
+  final type Spook[T, PT] = phantom.Spook[T, PT]
+  final val Spook: phantom.Spook.type = phantom.Spook
+
+  final type SafeSpook[E, T, PT] = phantom.SafeSpook[E, T, PT]
+  final val SafeSpook: phantom.SafeSpook.type = phantom.SafeSpook
 }

--- a/core/submodules/anomaly/src/main/scala/busymachines/pureharm/anomaly/PureharmAnomalyTypeDefinitions.scala
+++ b/core/submodules/anomaly/src/main/scala/busymachines/pureharm/anomaly/PureharmAnomalyTypeDefinitions.scala
@@ -68,4 +68,7 @@ trait PureharmAnomalyTypeDefinitions {
 
   final type NotImplementedCatastrophe = anomaly.NotImplementedCatastrophe
   final val NotImplementedCatastrophe: anomaly.NotImplementedCatastrophe.type = anomaly.NotImplementedCatastrophe
+
+  final type UnhandledCatastrophe = anomaly.UnhandledCatastrophe
+  final val UnhandledCatastrophe: anomaly.UnhandledCatastrophe.type = anomaly.UnhandledCatastrophe
 }

--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/CatsTypeAliases.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/CatsTypeAliases.scala
@@ -171,7 +171,6 @@ private[pureharm] trait CatsTypeAliases {
   final val Show: cats.Show.type = cats.Show
 
   //----------- cats-effect types -----------
-  @implicitNotFound("Custom Sync not found message")
   final type Sync[F[_]] = ce.Sync[F]
   final val Sync: ce.Sync.type = ce.Sync
 

--- a/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/CatsTypeAliases.scala
+++ b/effects-cats/src/main/scala/busymachines/pureharm/internals/effects/aliases/CatsTypeAliases.scala
@@ -17,7 +17,6 @@
   */
 package busymachines.pureharm.internals.effects.aliases
 
-import scala.annotation.implicitNotFound
 import scala.{concurrent => sc}
 
 import cats.{effect => ce}


### PR DESCRIPTION
Added aliases for:
- [core] `SafeSpook` and `Spook`
- [core] `UnhandledAnomaly`
- [config] for all `pureconfig` error types