### PR TITLE
[DB] Make doobie jsonMeta non-implicit

### DIFF
--- a/db/submodules/doobie/src/main/scala/busymachines/pureharm/internals/dbdoobie/PhantomTypeMetas.scala
+++ b/db/submodules/doobie/src/main/scala/busymachines/pureharm/internals/dbdoobie/PhantomTypeMetas.scala
@@ -50,7 +50,7 @@ trait PhantomTypeMetas {
     put:   Put[Underlying],
   ): Put[Phantom] = put.contramap(spook.despook)
 
-  implicit def jsonMeta[A](implicit codec: Codec[A]): Meta[A] =
+  def jsonMeta[A](implicit codec: Codec[A]): Meta[A] =
     Meta.Advanced
       .other[PGobject]("jsonb")
       .imap { a =>


### PR DESCRIPTION
You really don't want to wind up in a situation where some Meta is derived to map your type to JSON accidentally.

`pureharm` encourages this decision to be made explicit on a type-by-type basis.