### PR TITLE
Release: 0.0.7-M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,70 @@
 # pureharm
+
 New, better, iteration of our `busymachines-commons` — short for "pure harmony"
 
-Currently the project is under heavy development, and is mostly driven by company needs until a stable version can be put out. At the end of the day this is a principled utility library that provides all glue to make web server development a breeze. It encourages users to use the "pureharm" style, for each application creating, for instance, your own "myapp.effects" package, which is easily created by mixing in traits provided by pureharm + your own domain specific stuff. 
+Currently the project is under heavy development, and is mostly driven by company needs until a stable version can be
+put out. At the end of the day this is a principled utility library that provides all glue to make web server
+development a breeze. It encourages users to use the "pureharm" style, for each application creating, for instance, your
+own "myapp.effects" package, which is easily created by mixing in traits provided by pureharm + your own domain specific
+stuff.
 
-## sbt build
+## modules
 
 The available modules are:
 
-```scala
-val pureharmVersion: String = "0.0.5" //https://github.com/busymachines/pureharm/releases
+- kernel `0.0.7-M1` for Scala `2.13`
+    - `"com.busymachines" %% s"pureharm-core" % "0.0.7-M1"`
+        - [shapeless](https://github.com/milessabin/shapeless/releases) `2.4.0-M1`
+    - `"com.busymachines" %% s"pureharm-effects-cats" % "0.0.7-M1"`
+        - [cats](https://github.com/typelevel/cats/releases) `2.3.0`
+        - [cats-effect](https://github.com/typelevel/cats-effect/releases) `2.3.0`
+    - `"com.busymachines" %% s"pureharm-testkit" % "0.0.7-M1"`
+        - [scalatest](https://github.com/scalatest/scalatest/releases) `3.2.3`
+        - [log4cats](https://github.com/ChristopherDavenport/log4cats/releases) `1.1.1`
+        - [logback-classic](https://github.com/qos-ch/logback/releases) `1.2.3`
+- config `0.0.7-M1` for Scala `2.13`
+    - `"com.busymachines" %% s"pureharm-config" % "0.0.7-M1"`
+        - pureharm kernel `0.0.7-M1`
+        - [pureconfig](https://github.com/pureconfig/pureconfig/releases) `0.14.0`
+- json `0.0.7-M1` for Scala `2.13`
+    - `"com.busymachines" %% s"pureharm-json" % "0.0.7-M1"`
+        - pureharm kernel `0.0.7-M1`
+        - [circe](https://github.com/circe/circe/releases) `0.13.0`
+- db `0.0.7-M1` for Scala `2.13`
+    - `"com.busymachines" %% s"pureharm-db-core" % "0.0.7-M1"`
+        - pureharm kernel `0.0.7-M1`
+        - pureharm config `0.0.7-M1`
+    - `"com.busymachines" %% s"pureharm-db-core-flyway" % "0.0.7-M1"`
+        - [flyway](https://github.com/flyway/flyway/releases) `7.3.1`
+    - `"com.busymachines" %% s"pureharm-db-core-psql" % "0.0.7-M1"`
+        - [postgresql](https://github.com/pgjdbc/pgjdbc/releases) `42.2.18`
+        - [atto](https://github.com/tpolecat/atto/releases) `0.8.0`
+    - `"com.busymachines" %% s"pureharm-db-doobie" % "0.0.7-M1"`
+        - [doobie](https://github.com/tpolecat/doobie/releases) `0.10.0-M2`
+    - `"com.busymachines" %% s"pureharm-db-slick" % "0.0.7-M1"`
+        - [slick](https://github.com/slick/slick/releases) `3.3.3`
+        - [HikariCP](https://github.com/brettwooldridge/HikariCP/releases) `3.4.5`
+    - `"com.busymachines" %% s"pureharm-db-testkit-core" % "0.0.7-M1"`
+    - `"com.busymachines" %% s"pureharm-db-testkit-doobie" % "0.0.7-M1"`
+        - pureharm-db-testkit-core
+    - `"com.busymachines" %% s"pureharm-db-testkit-slick" % "0.0.7-M1"`
+        - pureharm-db-testkit-core
+- rest `0.0.7-M1` for Scala `2.13`
+    - `"com.busymachines" %% s"pureharm-rest-http4s-tapir" % "0.0.7-M1"`
+        - pureharm kernel `0.0.7-M1`
+        - pureharm json `0.0.7-M1`
+        - [http4s](https://github.com/http4s/http4s/releases) `0.21.14`
+        - [tapir](https://github.com/softwaremill/tapir/releases) `0.17.0`
+    - `"com.busymachines" %% s"pureharm-rest-http4s-tapir-testkit" % "0.0.7-M1"`
+        - pureharm kernel `0.0.7-M1`
+        - pureharm-rest-http4s-tapir
 
-def pureharm(m: String): ModuleID = "com.busymachines" %% s"pureharm-$m" % pureharmVersion
+## usage
 
-val pureharmCore:             ModuleID = pureharm("core")              withSources ()
-val pureharmCoreAnomaly:      ModuleID = pureharm("core-anomaly")      withSources ()
-val pureharmCorePhantom:      ModuleID = pureharm("core-phantom")      withSources ()
-val pureharmCoreIdentifiable: ModuleID = pureharm("core-identifiable") withSources ()
-val pureharmEffectsCats:      ModuleID = pureharm("effects-cats")      withSources ()
-val pureharmJsonCirce:        ModuleID = pureharm("json-circe")        withSources ()
-val pureharmConfig:           ModuleID = pureharm("config")            withSources ()
-
-val pureharmDBCore:       ModuleID = pureharm("db-core")        withSources ()
-val pureharmDBCoreFlyway: ModuleID = pureharm("db-core-flyway") withSources ()
-val pureharmDBSlick:      ModuleID = pureharm("db-slick")       withSources ()
-val pureharmDBPSQL:       ModuleID = pureharm("db-slick-psql")  withSources ()
-//------- OR --------
-
-libraryDependencies ++= Seq(
-  //pureharm-core brings in pureharm-core-anomaly, pureharm-core-phantom, and pureharm-core-identifiable.
-  "com.busymachines" %% s"pureharm-core"              % pureharmVersion,
-  "com.busymachines" %% s"pureharm-core-anomaly"      % pureharmVersion,
-  "com.busymachines" %% s"pureharm-core-phantom"      % pureharmVersion,
-  "com.busymachines" %% s"pureharm-core-identifiable" % pureharmVersion,
-  "com.busymachines" %% s"pureharm-effects-cats"      % pureharmVersion,
-  "com.busymachines" %% s"pureharm-json-circe"        % pureharmVersion,
-  "com.busymachines" %% s"pureharm-config"            % pureharmVersion,
-  "com.busymachines" %% s"pureharm-db-core"           % pureharmVersion,
-  "com.busymachines" %% s"pureharm-db-core-flyway"    % pureharmVersion,
-  "com.busymachines" %% s"pureharm-db-slick"          % pureharmVersion,
-  "com.busymachines" %% s"pureharm-db-slick-psql"     % pureharmVersion,
-)
-```
-
-## Usage
 Under construction. See [release notes](https://github.com/busymachines/pureharm/releases) and tests for examples.
 
 ## Copyright and License
 
-All code is available to you under the Apache 2.0 license, available at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) and also in the [LICENSE](./LICENSE) file.
+All code is available to you under the Apache 2.0 license, available
+at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0) and also in
+the [LICENSE](./LICENSE) file.

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@
 //#############################################################################
 //#############################################################################
 
-lazy val kernelVersion = "0.0.7-M1"
-lazy val configVersion = "0.0.7-M1"
-lazy val jsonVersion   = "0.0.7-M1"
-lazy val dbVersion     = "0.0.7-M1"
-lazy val restVersion   = "0.0.7-M1"
+lazy val kernelVersion = "0.0.7-SNAPSHOT"
+lazy val configVersion = "0.0.7-SNAPSHOT"
+lazy val jsonVersion   = "0.0.7-SNAPSHOT"
+lazy val dbVersion     = "0.0.7-SNAPSHOT"
+lazy val restVersion   = "0.0.7-SNAPSHOT"
 
 // format: off
 addCommandAlias("ph-useScala213", s"++${CompilerSettings.scala2_13}")

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@
 //#############################################################################
 //#############################################################################
 
-lazy val kernelVersion = "0.0.7-SNAPSHOT"
-lazy val configVersion = "0.0.7-SNAPSHOT"
-lazy val jsonVersion   = "0.0.7-SNAPSHOT"
-lazy val dbVersion     = "0.0.7-SNAPSHOT"
-lazy val restVersion   = "0.0.7-SNAPSHOT"
+lazy val kernelVersion = "0.0.7-M1"
+lazy val configVersion = "0.0.7-M1"
+lazy val jsonVersion   = "0.0.7-M1"
+lazy val dbVersion     = "0.0.7-M1"
+lazy val restVersion   = "0.0.7-M1"
 
 // format: off
 addCommandAlias("ph-useScala213", s"++${CompilerSettings.scala2_13}")

--- a/build.sbt
+++ b/build.sbt
@@ -25,67 +25,54 @@ lazy val jsonVersion   = "0.0.7-SNAPSHOT"
 lazy val dbVersion     = "0.0.7-SNAPSHOT"
 lazy val restVersion   = "0.0.7-SNAPSHOT"
 
-//see: https://github.com/liancheng/scalafix-organize-imports
-//and the project-specific config in .scalafix.conf
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.4.3"
-
 // format: off
 addCommandAlias("ph-useScala213", s"++${CompilerSettings.scala2_13}")
 addCommandAlias("ph-useScala30",  s"++${CompilerSettings.scala3_0}")
 
-lazy val kernelModules = List(
-  "core-anomaly",
-  "core-phantom",
-  "core-identifiable",
-  "effects-cats",
-  "testkit",
-)
-lazy val configModules = List(
-  "config",
-)
-lazy val jsonModules = List(
-  "json-circe",
-)
-lazy val dbModules = List(
-  "core",
-  "core-flyway",
-  "core-psql",
-  "doobie",
-  "slick",
-  "slick-psql",
-  "testkit-core",
-  "testkit-doobie",
-  "testkit-slick",
-)
+addCommandAlias("ph-publish-kernel-local", s"${publishAlias("kernel-publish")}")
+addCommandAlias("ph-publish-config-local", s"${publishAlias("config")}")
+addCommandAlias("ph-publish-json-local", s"${publishAlias("json-publish")}")
+addCommandAlias("ph-publish-db-local", s"${publishAlias("db-publish")}")
+addCommandAlias("ph-publish-rest-local", s"${publishAlias("rest-publish")}")
 
-lazy val restModules = List(
-  "rest-http4s-tapir",
-  "rest-http4s-tapir-testkit",
-)
-
-addCommandAlias("ph-publish-kernel-local", s"${sequence(kernelModules, localPublishAlias)}")
-addCommandAlias("ph-publish-config-local", s"${sequence(configModules, localPublishAlias)}")
-addCommandAlias("ph-publish-json-local", s"${sequence(jsonModules, localPublishAlias)}")
-addCommandAlias("ph-publish-db-local", s"${sequence(dbModules, localPublishAlias)}")
-addCommandAlias("ph-publish-rest-local", s"${sequence(restModules, localPublishAlias)}")
-
-addCommandAlias("ph-publish-kernel", s"${sequence(kernelModules, publishAlias)};sonatypeBundleRelease")
-addCommandAlias("ph-publish-config", s"${sequence(configModules, publishAlias)};sonatypeBundleRelease")
-addCommandAlias("ph-publish-json", s"${sequence(jsonModules, publishAlias)};sonatypeBundleRelease")
-addCommandAlias("ph-publish-db", s"${sequence(dbModules, publishAlias)};sonatypeBundleRelease")
-addCommandAlias("ph-publish-rest", s"${sequence(restModules, publishAlias)};sonatypeBundleRelease")
+//setting the version because sonatypePublishBundle looks for a folder with the version in ThisBuild... for whatever reason...
+addCommandAlias("ph-publish-kernel", s""";set version in ThisBuild := "$kernelVersion";${publishAlias("kernel-publish")}""")
+addCommandAlias("ph-publish-config", s""";set version in ThisBuild := "$configVersion";${publishAlias("config")}""")
+addCommandAlias("ph-publish-json", s""";set version in ThisBuild := "$jsonVersion";${publishAlias("json-publish")}""")
+addCommandAlias("ph-publish-db", s""";set version in ThisBuild := "$dbVersion";${publishAlias("db-publish")}""")
+addCommandAlias("ph-publish-rest", s""";set version in ThisBuild := "$restVersion";${publishAlias("rest-publish")}""")
 
 addCommandAlias("do213KernelRelease", ";ph-useScala213;ph-publish-kernel")
 addCommandAlias("do30KernelRelease", ";ph-useScala30;ph-publish-kernel")
-addCommandAlias("doMainRelease", ";do213MainRelease;do30KernelRelease")
-addCommandAlias("doMainLocal", ";ph-useScala213;ph-publish-kernel-local;ph-useScala30;ph-publish-kernel-local")
+addCommandAlias("doKernelRelease", ";do213KernelRelease;do30KernelRelease")
+addCommandAlias("doKernelLocal", ";ph-useScala213;ph-publish-kernel-local;ph-useScala30;ph-publish-kernel-local")
 
-addCommandAlias("lint", ";scalafixEnable;rebuild;scalafix;scalafmtAll")
+addCommandAlias("do213ConfigRelease", ";ph-useScala213;ph-publish-config")
+addCommandAlias("do30ConfigRelease", ";ph-useScala30;ph-publish-config")
+addCommandAlias("doConfigRelease", ";do213ConfigRelease;do30ConfigRelease")
+addCommandAlias("doConfigLocal", ";ph-useScala213;ph-publish-config-local;ph-useScala30;ph-publish-config-local")
+
+addCommandAlias("do213JsonRelease", ";ph-useScala213;ph-publish-json")
+addCommandAlias("do30JsonRelease", ";ph-useScala30;ph-publish-json")
+addCommandAlias("doJsonRelease", ";do213JsonRelease;do30JsonRelease")
+addCommandAlias("doJsonLocal", ";ph-useScala213;ph-publish-json-local;ph-useScala30;ph-publish-json-local")
+
+addCommandAlias("do213DBRelease", ";ph-useScala213;ph-publish-db")
+addCommandAlias("do30DBRelease", ";ph-useScala30;ph-publish-db")
+addCommandAlias("doDBRelease", ";do213DBRelease;do30DBRelease")
+addCommandAlias("doDBLocal", ";ph-useScala213;ph-publish-db-local;ph-useScala30;ph-publish-db-local")
+
+addCommandAlias("do213RestRelease", ";ph-useScala213;ph-publish-rest")
+addCommandAlias("do30RestRelease", ";ph-useScala30;ph-publish-rest")
+addCommandAlias("doRestRelease", ";do213RestRelease;do30RestRelease")
+addCommandAlias("doRestLocal", ";ph-useScala213;ph-publish-rest-local;ph-useScala30;ph-publish-rest-local")
+
+addCommandAlias("do213Release", ";ph-useScala213;ph-publish-kernel;ph-publish-config;ph-publish-json;ph-publish-db;ph-publish-rest")
+addCommandAlias("do30Release", ";ph-useScala30;ph-publish-kernel;ph-publish-config;ph-publish-json;ph-publish-db;ph-publish-rest")
 
 def rebuildAlias(mod: String): String = s"pureharm-$mod/clean;pureharm-$mod/compile;pureharm-$mod/Test/compile"
 def localPublishAlias(mod: String): String = s"${rebuildAlias(mod)};pureharm-$mod/publishLocal"
-def publishAlias(mod: String): String = s"${rebuildAlias(mod)};pureharm-$mod/publishSigned;"
-def sequence(l: List[String], f: String => String): String = l.map(f).mkString(";")
+def publishAlias(mod: String): String = s"${rebuildAlias(mod)};pureharm-$mod/publishSigned;sonatypeBundleRelease"
 // format: on
 //*****************************************************************************
 //*****************************************************************************
@@ -100,6 +87,7 @@ lazy val root = Project(id = "pureharm", base = file("."))
     `core-anomaly`,
     `core-phantom`,
     `core-identifiable`,
+    `core`,
     `effects-cats`,
     testkit,
     `config`,
@@ -118,9 +106,35 @@ lazy val root = Project(id = "pureharm", base = file("."))
   )
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//+++++++++++++++++++++++++++++++++++ CORE ++++++++++++++++++++++++++++++++++++
+//++++++++++++++++++++++++++++++++++ KERNEL +++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+//used only as a proxy for triggering publish of all kernel modules, does not contain source code.
+lazy val `kernel-publish` = Project(id = s"pureharm-kernel-publish", base = file(s"kernel"))
+  .settings(name := s"pureharm-kernel-publish", version := kernelVersion)
+  .settings(PublishingSettings.noPublishSettings)
+  .settings(CompilerSettings.commonSettings)
+  .aggregate(
+    `core`,
+    `core-anomaly`,
+    `core-phantom`,
+    `core-identifiable`,
+    `effects-cats`,
+    `testkit`,
+  )
+
+lazy val `core` = kernelModule("core")
+  .settings(PublishingSettings.sonatypeSettings)
+  .settings(CompilerSettings.commonSettings)
+  .dependsOn(
+    `core-anomaly`,
+    `core-phantom`,
+    `core-identifiable`,
+    `effects-cats`,
+    `testkit`,
+  )
+
+//#############################################################################
 lazy val `core-anomaly` = kernelModule("core-anomaly")
   .settings(PublishingSettings.sonatypeSettings)
   .settings(CompilerSettings.commonSettings)
@@ -205,6 +219,15 @@ lazy val `testkit` = kernelModule("testkit")
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //++++++++++++++++++++++++++++++++++++ JSON +++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//used only as a proxy for triggering publish of all kernel modules, does not contain source code.
+lazy val `json-publish` = Project(id = s"pureharm-json-publish", base = file(s"json"))
+  .settings(name := s"pureharm-json-publish", version := kernelVersion)
+  .settings(PublishingSettings.noPublishSettings)
+  .settings(CompilerSettings.commonSettings)
+  .aggregate(
+    `json-circe`
+  )
 
 lazy val `json-circe` = jsonModule("circe")
   .settings(PublishingSettings.sonatypeSettings)
@@ -620,7 +643,7 @@ def kernelModule(mod: String): Project =
   Project(id = s"pureharm-$mod", base = file(s"kernel/$mod"))
     .settings(name := s"pureharm-$mod", version := kernelVersion)
 
-def jsonModule(mod: String): Project =
+def jsonModule(mod:   String): Project =
   Project(id = s"pureharm-json-$mod", base = file(s"json/$mod"))
     .settings(name := s"pureharm-json-$mod", version := jsonVersion)
 
@@ -628,10 +651,10 @@ def configModule: Project =
   Project(id = s"pureharm-config", base = file(s"config"))
     .settings(name := s"pureharm-config", version := configVersion)
 
-def dbModule(mod:   String): Project =
+def dbModule(mod:     String): Project =
   Project(id = s"pureharm-db-$mod", base = file(s"db/$mod"))
     .settings(name := s"pureharm-db-$mod", version := dbVersion)
 
-def restModule(mod: String): Project =
+def restModule(mod:   String): Project =
   Project(id = s"pureharm-rest-$mod", base = file(s"rest/$mod"))
     .settings(name := s"pureharm-rest-$mod", version := restVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -36,11 +36,11 @@ addCommandAlias("ph-publish-db-local", s"${publishAlias("db-publish")}")
 addCommandAlias("ph-publish-rest-local", s"${publishAlias("rest-publish")}")
 
 //setting the version because sonatypePublishBundle looks for a folder with the version in ThisBuild... for whatever reason...
-addCommandAlias("ph-publish-kernel", s""";set version in ThisBuild := "$kernelVersion";${publishAlias("kernel-publish")}""")
-addCommandAlias("ph-publish-config", s""";set version in ThisBuild := "$configVersion";${publishAlias("config")}""")
-addCommandAlias("ph-publish-json", s""";set version in ThisBuild := "$jsonVersion";${publishAlias("json-publish")}""")
-addCommandAlias("ph-publish-db", s""";set version in ThisBuild := "$dbVersion";${publishAlias("db-publish")}""")
-addCommandAlias("ph-publish-rest", s""";set version in ThisBuild := "$restVersion";${publishAlias("rest-publish")}""")
+addCommandAlias("ph-publish-kernel", s""";clean;set version in ThisBuild := "$kernelVersion";${publishAlias("kernel-publish")}""")
+addCommandAlias("ph-publish-config", s""";clean;set version in ThisBuild := "$configVersion";${publishAlias("config")}""")
+addCommandAlias("ph-publish-json", s""";clean;set version in ThisBuild := "$jsonVersion";${publishAlias("json-publish")}""")
+addCommandAlias("ph-publish-db", s""";clean;set version in ThisBuild := "$dbVersion";${publishAlias("db-publish")}""")
+addCommandAlias("ph-publish-rest", s""";clean;set version in ThisBuild := "$restVersion";${publishAlias("rest-publish")}""")
 
 addCommandAlias("do213KernelRelease", ";ph-useScala213;ph-publish-kernel")
 addCommandAlias("do30KernelRelease", ";ph-useScala30;ph-publish-kernel")
@@ -220,9 +220,9 @@ lazy val `testkit` = kernelModule("testkit")
 //++++++++++++++++++++++++++++++++++++ JSON +++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-//used only as a proxy for triggering publish of all kernel modules, does not contain source code.
+//used only as a proxy for triggering publish of all json modules, does not contain source code.
 lazy val `json-publish` = Project(id = s"pureharm-json-publish", base = file(s"json"))
-  .settings(name := s"pureharm-json-publish", version := kernelVersion)
+  .settings(name := s"pureharm-json-publish", version := jsonVersion)
   .settings(PublishingSettings.noPublishSettings)
   .settings(CompilerSettings.commonSettings)
   .aggregate(
@@ -268,6 +268,22 @@ lazy val `config` = configModule
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //++++++++++++++++++++++++++++++++++++ DB +++++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//used only as a proxy for triggering publish of all db modules, does not contain source code.
+lazy val `db-publish` = Project(id = s"pureharm-db-publish", base = file(s"db"))
+  .settings(name := s"pureharm-db-publish", version := dbVersion)
+  .settings(PublishingSettings.noPublishSettings)
+  .settings(CompilerSettings.commonSettings)
+  .aggregate(
+    `db-core`,
+    `db-core-psql`,
+    `db-core-flyway`,
+    `db-testkit-core`,
+    `db-doobie`,
+    `db-testkit-doobie`,
+    `db-slick`,
+    `db-testkit-slick`,
+  )
 
 lazy val `db-core` = dbModule("core")
   .settings(PublishingSettings.sonatypeSettings)
@@ -459,6 +475,16 @@ lazy val `db-testkit-slick` = dbModule("testkit-slick")
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++ HTTP ++++++++++++++++++++++++++++++++++++
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//used only as a proxy for triggering publish of all db modules, does not contain source code.
+lazy val `rest-publish` = Project(id = s"pureharm-rest-publish", base = file(s"rest"))
+  .settings(name := s"pureharm-rest-publish", version := restVersion)
+  .settings(PublishingSettings.noPublishSettings)
+  .settings(CompilerSettings.commonSettings)
+  .aggregate(
+    `rest-http4s-tapir`,
+    `rest-http4s-tapir-testkit`,
+  )
 
 lazy val `rest-http4s-tapir` = restModule("http4s-tapir")
   .settings(PublishingSettings.sonatypeSettings)

--- a/project/PublishingSettings.scala
+++ b/project/PublishingSettings.scala
@@ -1,5 +1,4 @@
-/**
-  * Copyright (c) 2019 BusyMachines
+/** Copyright (c) 2019 BusyMachines
   *
   * See company homepage at: https://www.busymachines.com/
   *
@@ -21,8 +20,7 @@ import sbt.Keys._
 import xerial.sbt.Sonatype.SonatypeKeys._
 import com.jsuereth.sbtpgp.PgpKeys._
 
-/**
-  * All instructions for publishing to sonatype can be found on the sbt-plugin page:
+/** All instructions for publishing to sonatype can be found on the sbt-plugin page:
   * http://www.scala-sbt.org/release/docs/Using-Sonatype.html
   *
   * and some here:
@@ -63,6 +61,8 @@ object PublishingSettings {
     publishMavenStyle          := true,
     pomIncludeRepository       := (_ => false),
     //new since sbt-pgp 3.4, see: https://github.com/xerial/sbt-sonatype/#uploading-artifacts-in-parallel
+    sonatypeBundleDirectory    := (ThisBuild / baseDirectory).value / target.value.getName / "sonatype-staging" / version.value,
+    sonatypeSessionName        := s"[sbt-sonatype] ${name.value} ${version.value}",
     publishTo                  := sonatypePublishToBundle.value,
     licenses                   := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
     scmInfo                    := Option(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,7 +30,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5") //https://github.com/x
   *
   * https://github.com/sbt/sbt-pgp/releases
   */
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1") //https://github.com/sbt/sbt-pgp/releases
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1") //https://github.com/sbt/sbt-pgp/releases
 
 /** build configured in ``project/ReleaseProcess``
   *


### PR DESCRIPTION
Theoretically, now the library is splitt into 5 independently versioned components. But this first release, they all share 0.0.7-M1 now.

Notable changes:
- drops Scala 2.12 support, moving closer to Scala 3.0.0 support.
- a bunch of version upgrades (see bellow)

- kernel `0.0.7-M1` for Scala `2.13`
    - `"com.busymachines" %% s"pureharm-core" % "0.0.7-M1"`
        - [shapeless](https://github.com/milessabin/shapeless/releases) `2.4.0-M1`
    - `"com.busymachines" %% s"pureharm-effects-cats" % "0.0.7-M1"`
        - [cats](https://github.com/typelevel/cats/releases) `2.3.0`
        - [cats-effect](https://github.com/typelevel/cats-effect/releases) `2.3.0`
    - `"com.busymachines" %% s"pureharm-testkit" % "0.0.7-M1"`
        - [scalatest](https://github.com/scalatest/scalatest/releases) `3.2.3`
        - [log4cats](https://github.com/ChristopherDavenport/log4cats/releases) `1.1.1`
        - [logback-classic](https://github.com/qos-ch/logback/releases) `1.2.3`
- config `0.0.7-M1` for Scala `2.13`
    - `"com.busymachines" %% s"pureharm-config" % "0.0.7-M1"`
        - pureharm kernel `0.0.7-M1`
        - [pureconfig](https://github.com/pureconfig/pureconfig/releases) `0.14.0`
- json `0.0.7-M1` for Scala `2.13`
    - `"com.busymachines" %% s"pureharm-json" % "0.0.7-M1"`
        - pureharm kernel `0.0.7-M1`
        - [circe](https://github.com/circe/circe/releases) `0.13.0`
- db `0.0.7-M1` for Scala `2.13`
    - `"com.busymachines" %% s"pureharm-db-core" % "0.0.7-M1"`
        - pureharm kernel `0.0.7-M1`
        - pureharm config `0.0.7-M1`
    - `"com.busymachines" %% s"pureharm-db-core-flyway" % "0.0.7-M1"`
        - [flyway](https://github.com/flyway/flyway/releases) `7.3.1`
    - `"com.busymachines" %% s"pureharm-db-core-psql" % "0.0.7-M1"`
        - [postgresql](https://github.com/pgjdbc/pgjdbc/releases) `42.2.18`
        - [atto](https://github.com/tpolecat/atto/releases) `0.8.0`
    - `"com.busymachines" %% s"pureharm-db-doobie" % "0.0.7-M1"`
        - [doobie](https://github.com/tpolecat/doobie/releases) `0.10.0-M2`
    - `"com.busymachines" %% s"pureharm-db-slick" % "0.0.7-M1"`
        - [slick](https://github.com/slick/slick/releases) `3.3.3`
        - [HikariCP](https://github.com/brettwooldridge/HikariCP/releases) `3.4.5`
    - `"com.busymachines" %% s"pureharm-db-testkit-core" % "0.0.7-M1"`
    - `"com.busymachines" %% s"pureharm-db-testkit-doobie" % "0.0.7-M1"`
        - pureharm-db-testkit-core
    - `"com.busymachines" %% s"pureharm-db-testkit-slick" % "0.0.7-M1"`
        - pureharm-db-testkit-core
- rest `0.0.7-M1` for Scala `2.13`
    - `"com.busymachines" %% s"pureharm-rest-http4s-tapir" % "0.0.7-M1"`
        - pureharm kernel `0.0.7-M1`
        - pureharm json `0.0.7-M1`
        - [http4s](https://github.com/http4s/http4s/releases) `0.21.14`
        - [tapir](https://github.com/softwaremill/tapir/releases) `0.17.0`
    - `"com.busymachines" %% s"pureharm-rest-http4s-tapir-testkit" % "0.0.7-M1"`
        - pureharm kernel `0.0.7-M1`
        - pureharm-rest-http4s-tapir