### PR TITLE
Bugfix: pureharm core release 0.0.7-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@
 //#############################################################################
 //#############################################################################
 
-lazy val kernelVersion = "0.0.7-SNAPSHOT"
-lazy val configVersion = "0.0.7-SNAPSHOT"
-lazy val jsonVersion   = "0.0.7-SNAPSHOT"
-lazy val dbVersion     = "0.0.7-SNAPSHOT"
-lazy val restVersion   = "0.0.7-SNAPSHOT"
+lazy val kernelVersion = "0.0.7-M2"
+lazy val configVersion = "0.0.7-M2"
+lazy val jsonVersion   = "0.0.7-M2"
+lazy val dbVersion     = "0.0.7-M2"
+lazy val restVersion   = "0.0.7-M2"
 
 // format: off
 addCommandAlias("ph-useScala213", s"++${CompilerSettings.scala2_13}")

--- a/build.sbt
+++ b/build.sbt
@@ -130,8 +130,6 @@ lazy val `core` = kernelModule("core")
     `core-anomaly`,
     `core-phantom`,
     `core-identifiable`,
-    `effects-cats`,
-    `testkit`,
   )
 
 //#############################################################################

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@
 //#############################################################################
 //#############################################################################
 
-lazy val kernelVersion = "0.0.7-M2"
-lazy val configVersion = "0.0.7-M2"
-lazy val jsonVersion   = "0.0.7-M2"
-lazy val dbVersion     = "0.0.7-M2"
-lazy val restVersion   = "0.0.7-M2"
+lazy val kernelVersion = "0.0.7-SNAPSHOT"
+lazy val configVersion = "0.0.7-SNAPSHOT"
+lazy val jsonVersion   = "0.0.7-SNAPSHOT"
+lazy val dbVersion     = "0.0.7-SNAPSHOT"
+lazy val restVersion   = "0.0.7-SNAPSHOT"
 
 // format: off
 addCommandAlias("ph-useScala213", s"++${CompilerSettings.scala2_13}")

--- a/kernel/core/src/main/scala/busymachines/pureharm/PureharmCoreTypeDefinitions.scala
+++ b/kernel/core/src/main/scala/busymachines/pureharm/PureharmCoreTypeDefinitions.scala
@@ -1,0 +1,41 @@
+/** Copyright (c) 2019 BusyMachines
+  *
+  * See company homepage at: https://www.busymachines.com/
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package busymachines.pureharm
+
+/** Convenience trait to mix in into your own domain specific
+  * modules for easy single-import experiences
+  *
+  * @author Lorand Szakacs, https://github.com/lorandszakacs
+  * @since 04 Apr 2019
+  */
+trait PureharmCoreTypeDefinitions {
+  final type FieldName = identifiable.FieldName.Type
+  final val FieldName: identifiable.FieldName.type = identifiable.FieldName
+
+  final type Identifiable[T, ID] = identifiable.Identifiable[T, ID]
+  final val Identifiable: identifiable.Identifiable.type = identifiable.Identifiable
+
+  final type PhantomType[T]        = phantom.PhantomType[T]
+  final type SafePhantomType[E, T] = phantom.SafePhantomType[E, T]
+  final type AttemptPhantomType[T] = phantom.SafePhantomType[Throwable, T]
+
+  final type Spook[T, PT] = phantom.Spook[T, PT]
+  final val Spook: phantom.Spook.type = phantom.Spook
+
+  final type SafeSpook[E, T, PT] = phantom.SafeSpook[E, T, PT]
+  final val SafeSpook: phantom.SafeSpook.type = phantom.SafeSpook
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 #https://github.com/sbt/sbt/releases
-sbt.version=1.4.4
+sbt.version=1.4.5


### PR DESCRIPTION
Revive lost `pureharm-core` module which added aliases